### PR TITLE
🐛 fix(tests): disable Spring Framework 7 context pausing in test cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,21 @@
                 <configuration>
                     <systemPropertyVariables>
                         <axon.test.eventstore>${axon.test.eventstore}</axon.test.eventstore>
+                        <!--
+                            Disable Spring Framework 7's "Context Pausing" for the test cache.
+
+                            Spring 7 pauses cached ApplicationContexts that aren't currently in use and restarts
+                            them on demand (DefaultContextCache.restartContextIfNecessary). Axon Framework 5's
+                            lifecycle handlers aren't restart-symmetric: command handler subscriptions aren't
+                            removed on stop, and PooledStreamingEventProcessor executors are terminated on stop
+                            with no recreation on restart. Both surface as failures during the second start
+                            (DuplicateCommandHandlerSubscriptionException, RejectedExecutionException).
+
+                            Setting this to `never` is the Spring-documented escape hatch
+                            (see https://docs.spring.io/spring-framework/reference/testing/testcontext-framework/ctx-management/context-pausing.html).
+                            Remove once Axon Framework 5 supports Spring Lifecycle stop+start cycles.
+                        -->
+                        <spring.test.context.cache.pause>never</spring.test.context.cache.pause>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Summary

Fixes the flaky postgres-matrix CI failures by setting `spring.test.context.cache.pause=never` in the surefire `<systemPropertyVariables>`. Disables Spring Framework 7's automatic test-cache context pause/restart, which surfaces two distinct Axon Framework 5 lifecycle bugs.

## Root cause

Spring Framework 7 / Spring Boot 4 introduced [Context Pausing](https://docs.spring.io/spring-framework/reference/testing/testcontext-framework/ctx-management/context-pausing.html): a cached `ApplicationContext` is `Lifecycle.stop()`-ed when no longer in use and `Lifecycle.start()`-ed on demand (`DefaultContextCache.restartContextIfNecessary` → `AbstractApplicationContext.restart()`).

Axon Framework 5's lifecycle handlers are not yet restart-symmetric, so the second start trips on two paths:

- **`PooledStreamingEventProcessor`** — the `onShutdown` handler terminates the coordinator/worker `ScheduledExecutorService`, but the `onStart` handler does not recreate it. On restart `Coordinator.start()` submits the `CoordinationTask` to a shut-down pool → `RejectedExecutionException`.
- **`SimpleCommandHandlingModule`** — the `onStart` handler re-runs and re-subscribes the same command handler that was never unsubscribed on stop → `DuplicateCommandHandlerSubscriptionException`.

Observed CI symptoms:
- `WhenWeekStartedThenProclaimWeekSymbolSpringSliceTest` → `Failed to start bean 'axon-start-lifecycle-handler-6'` caused by `DuplicateCommandHandlerSubscriptionException` on `Astrologers.ProclaimWeekSymbol`.
- `CommandHandlerResultAxonConverterSpringTest` (before its earlier slim-down) → `Failed to start bean 'axon-start-lifecycle-handler-4'` caused by `RejectedExecutionException` from the terminated `Workflow` processor pool.

## Fix

One-line surefire system property — the Spring-documented escape hatch for ["Lifecycle components that cannot or should not opt out of pausing"](https://docs.spring.io/spring-framework/reference/testing/testcontext-framework/ctx-management/context-pausing.html):

```xml
<spring.test.context.cache.pause>never</spring.test.context.cache.pause>
```

Disables only the pause feature; cache itself stays intact, so suite runtime is unaffected. Test JVM scope only — production behaviour is not touched.

## Test plan

- [x] `./mvnw test -Dgroups=integration -Dtest='WhenWeekStartedThenProclaimWeekSymbolSpringSliceTest'` passes locally (previously failed in postgres CI with `DuplicateCommandHandlerSubscriptionException`).
- [x] `./mvnw test -Dtest='CommandHandlerResultAxonConverterSpringTest'` passes locally.
- [x] CI green on both matrix legs (`axonserver` + `postgres`).

## Follow-ups

Once Axon Framework 5 ships proper support for Spring `Lifecycle.stop()` → `Lifecycle.start()` cycles (upstream branch `fix/psep-start-stop` addresses the PSEP side):

1. Remove the `spring.test.context.cache.pause` property from `pom.xml`.
2. Optionally revert commit `14b38e9` (`slim down CommandHandlerResultAxonConverterSpringTest`) to restore the full-app context test, which is more useful for catching `defaultAxonObjectMapper` wiring bugs end-to-end.