### PR TITLE
✨ feat(platform): connect to AxonIQ Platform + Conductor workspace polish

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,31 @@
+# Files Conductor copies from the repo root into each new workspace.
+# Uses .gitignore syntax. See https://conductor.build/docs/reference/files-to-copy
+
+# --- Env / local config ---
+.env
+.env.*
+!.env.example
+.proophboard/.env.local
+
+# --- IntelliJ IDEA: shareable project files ---
+# Run configs only when stored as project files (tick "Store as project file" in IDE).
+.idea/runConfigurations/
+
+# Datasources (definitions). NOTE: dataSources.local.xml contains your encrypted
+# credentials and is tied to your IDE keystore — copying it across workspaces
+# is fine on the same machine but won't work for other developers.
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/dataSources/
+
+# Other stable IDE project settings worth sharing across workspaces
+.idea/compiler.xml
+.idea/encodings.xml
+.idea/jarRepositories.xml
+.idea/kotlinc.xml
+.idea/misc.xml
+.idea/vcs.xml
+.idea/.gitignore
+
+# Explicitly DO NOT copy: .idea/workspace.xml — it carries per-window UI state
+# (open tabs, last-run config, breakpoints, etc.) that should stay workspace-local.

--- a/conductor.json
+++ b/conductor.json
@@ -2,7 +2,7 @@
   "scripts": {
     "setup": "./mvnw -B -q -DskipTests dependency:go-offline test-compile",
     "run": "./mvnw -B test",
-    "archive": ""
+    "archive": "docker compose down -v --remove-orphans"
   },
   "runScriptMode": "concurrent"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
             <version>${axon.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.axoniq.platform</groupId>
+            <artifactId>axoniq-platform-spring-boot-starter</artifactId>
+            <version>${axon.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.axonframework.extensions.spring</groupId>
             <artifactId>axon-spring-boot-starter-test</artifactId>
             <version>${axon.version}</version>

--- a/src/main/resources/application-axoniqplatform.yaml
+++ b/src/main/resources/application-axoniqplatform.yaml
@@ -1,0 +1,5 @@
+axoniq:
+  platform:
+    application-name: heroesofddd
+    credentials: ${HEROES_AXON5_PLATFORM_CREDENTIALS}
+    dlq-mode: full

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -50,6 +50,12 @@ cors:
     - "*"
   allow-credentials: true
 
+axoniq:
+  platform:
+    application-name: heroesofddd
+    credentials: ${HEROES_AXON5_PLATFORM_CREDENTIALS:XYZ}
+    dlq-mode: full
+
 axon:
   axonserver:
     context: default

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -50,12 +50,6 @@ cors:
     - "*"
   allow-credentials: true
 
-axoniq:
-  platform:
-    application-name: heroesofddd
-    credentials: ${HEROES_AXON5_PLATFORM_CREDENTIALS:XYZ}
-    dlq-mode: full
-
 axon:
   axonserver:
     context: default


### PR DESCRIPTION
## Summary
- Wire up **AxonIQ Platform** via `axoniq-platform-spring-boot-starter`, with config isolated to a dedicated `axoniqplatform` Spring profile so the default boot path is unaffected; credential is read from `HEROES_AXON5_PLATFORM_CREDENTIALS` and fails fast when missing.
- Add `.worktreeinclude` so Conductor copies shareable `.idea/` files (project-scoped run configs, datasource definitions, stable project settings) into new workspaces while keeping `workspace.xml` per-workspace.
- Set `conductor.json` `scripts.archive` to `docker compose down -v --remove-orphans` so archiving a workspace cleans up its Compose project (containers + volumes + orphans).

## Test plan
- [x] App boots without the new profile and behaves as before.
- [x] `SPRING_PROFILES_ACTIVE=axoniqplatform ./mvnw spring-boot:run` connects to AxonIQ Platform when `HEROES_AXON5_PLATFORM_CREDENTIALS` is set, and fails fast when it isn't.
- [x] A new Conductor workspace created from this branch picks up `.idea/runConfigurations/` and datasource files; `workspace.xml` is not copied.
- [x] Archiving a workspace removes its Docker Compose containers and volumes.