### PR TITLE
chore(dx): migrate conductor.json to .conductor/settings.toml

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,7 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+archive = "docker compose down -v --remove-orphans"
+run = "./mvnw -B test"
+run_mode = "concurrent"
+setup = "./mvnw -B -q -DskipTests dependency:go-offline test-compile"

--- a/conductor.json
+++ b/conductor.json
@@ -1,8 +1,0 @@
-{
-  "scripts": {
-    "setup": "./mvnw -B -q -DskipTests dependency:go-offline test-compile",
-    "run": "./mvnw -B test",
-    "archive": "docker compose down -v --remove-orphans"
-  },
-  "runScriptMode": "concurrent"
-}


### PR DESCRIPTION
This PR migrates the legacy `conductor.json` configuration to the new `.conductor/settings.toml` format.

Generated by Conductor.