### PR TITLE
🧪 Add Pitest mutation testing with one-click CI workflow

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,48 @@
+# Manually-triggered Pitest mutation coverage run.
+#
+# Why manual only:
+#   Mutation runs are expensive — the project's Spring/Testcontainers tests
+#   are included in the Pitest scope. Running per-commit would burn CI minutes
+#   without commensurate value for an educational repository.
+#
+# How to trigger:
+#   GitHub → Actions → "🧬 Mutation Testing" → "Run workflow" → pick branch.
+#   The HTML report is uploaded as the `pit-report` artifact.
+
+name: "🧬 Mutation Testing"
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pitest:
+    name: "Pitest mutation coverage"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: 🛎️ Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🔧 Set up JDK 23
+        uses: actions/setup-java@v4
+        with:
+          java-version: '23'
+          distribution: 'zulu'
+          cache: maven
+
+      - name: 🧬 Run mutation coverage
+        run: ./mvnw -B test org.pitest:pitest-maven:mutationCoverage --file pom.xml
+
+      - name: 📤 Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pit-report
+          path: target/pit-reports/
+          if-no-files-found: error
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Open the *Actions* tab → "🧬 Mutation Testing" → "Run workflow". The HTML 
 is uploaded as a workflow artifact. CI is **manual only** — Pitest is not run
 on every push or PR because mutation runs are expensive.
 
-See [docs/mutation-testing.md](docs/mutation-testing.md) for the deeper guide:
+See [docs/MUTATION_TESTING.md](docs/MUTATION_TESTING.md) for the deeper guide:
 how to read the report, recognise equivalent mutants, and how mutation testing
 complements the `Given/When/Then` style.
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ open target/pit-reports/index.html
 
 A one-click GitHub Actions workflow lives at
 [`.github/workflows/mutation-testing.yml`](.github/workflows/mutation-testing.yml).
-Open the *Actions* tab → "Mutation Testing" → "Run workflow". The HTML report
+Open the *Actions* tab → "🧬 Mutation Testing" → "Run workflow". The HTML report
 is uploaded as a workflow artifact. CI is **manual only** — Pitest is not run
 on every push or PR because mutation runs are expensive.
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,73 @@ internal class RecruitCreatureSpringSliceTest @Autowired constructor(
 }
 ```
 
+### 🧬 Mutation Testing with Pitest
+
+Mutation testing answers a question that line/branch coverage cannot:
+**does the test suite actually fail when the production code is wrong?**
+
+[Pitest](https://pitest.org/) rewrites bytecode to introduce small faults
+("mutants") into `decide()` / `evolve()` and re-runs the tests. A *killed*
+mutant means a test caught the regression; a *surviving* mutant is a gap in
+the assertions.
+
+This works particularly well for our vertical slices because `decide()` and
+`evolve()` are pure functions exercised through `AxonTestFixture` with the
+`Given/When/Then` DSL — tests observe only emitted events and reconstructed
+state, so killed mutants reflect real behavioural coverage.
+
+Pitest is wired against **all tests in the project** — both pure
+`AxonTestFixture` unit tests and `@HeroesAxonSpringBootTest`-based slice tests
+(which still drive their slice through the same `AxonTestFixture` DSL).
+
+#### Run it locally
+
+Prerequisite: Java 21 (already required for the project). Testcontainers
+starts Axon Server automatically during the mutation run — no manual
+`docker compose up` needed.
+
+Full mutation run over all classes and tests:
+
+```bash
+./mvnw test org.pitest:pitest-maven:mutationCoverage
+```
+
+Scope to a single bounded context while iterating (much faster feedback):
+
+```bash
+./mvnw test org.pitest:pitest-maven:mutationCoverage \
+  -DtargetClasses=com.dddheroes.heroesofddd.creaturerecruitment.* \
+  -DtargetTests=com.dddheroes.heroesofddd.creaturerecruitment.*
+```
+
+Scope to a single slice:
+
+```bash
+./mvnw test org.pitest:pitest-maven:mutationCoverage \
+  -DtargetClasses=com.dddheroes.heroesofddd.creaturerecruitment.write.recruitcreaturedcb.* \
+  -DtargetTests=com.dddheroes.heroesofddd.creaturerecruitment.write.recruitcreaturedcb.*
+```
+
+Open the HTML report:
+
+```bash
+open target/pit-reports/index.html
+```
+
+(On Linux replace `open` with `xdg-open`.)
+
+#### Run it on CI
+
+A one-click GitHub Actions workflow lives at
+[`.github/workflows/mutation-testing.yml`](.github/workflows/mutation-testing.yml).
+Open the *Actions* tab → "Mutation Testing" → "Run workflow". The HTML report
+is uploaded as a workflow artifact. CI is **manual only** — Pitest is not run
+on every push or PR because mutation runs are expensive.
+
+See [docs/mutation-testing.md](docs/mutation-testing.md) for the deeper guide:
+how to read the report, recognise equivalent mutants, and how mutation testing
+complements the `Given/When/Then` style.
+
 ### 💼 Hire me
 
 If you'd like to hire me for Domain-Driven Design and/or Event Sourcing projects I'm available to work with:

--- a/docs/MUTATION_TESTING.md
+++ b/docs/MUTATION_TESTING.md
@@ -175,6 +175,41 @@ A practical workflow: filter the report to surviving mutants in `*.Slice.kt`
 first. That's where killing mutants directly improves your `decide()` /
 `evolve()` confidence.
 
+### Triage heuristics learned from this codebase
+
+Real survivor triage done on this repo surfaced patterns worth knowing:
+
+- **Impossible line numbers = inlined code.** A survivor at line 166 of a
+  161-line file is not a bug in Pitest — Kotlin `inline` functions copy
+  their bytecode (with original line numbers) into each call site. In this
+  repo every `@CommandHandler` uses the inlined `resultOf { }` SDK helper,
+  so each handler "contains" a copy of its branches at out-of-range line
+  numbers. These mutants are duplicated per call site and mostly
+  equivalent — skip them.
+- **The `?.let { } ?: ` idiom manufactures an equivalent mutant.** Kotlin
+  compiles `result?.let { ok(it) } ?: notFound()` with *two* null checks:
+  the safe-call on `result`, and the elvis re-checking the let-block's
+  *result* — which, being `ResponseEntity.ok(...)`, is never null. The
+  second check is unkillable by any test. When an apparently-tested line
+  keeps a survivor, suspect the idiom, not the test — and **keep the
+  idiomatic Kotlin**: bending production code to please the tool inverts
+  the point of mutation testing. Accept the survivor as a known
+  equivalent. (The commercial Arcmutate Kotlin plugin filters exactly
+  this class of mutants automatically.)
+- **Data-class `equals()` bypasses getters.** Asserting whole-object
+  equality (`containsExactly(expected)`) never calls the generated
+  getters, so return-value mutants on them survive. One per-field
+  assertion (`assertThat(item.x).isEqualTo(...)`) kills the whole family.
+- **`hashCode` needs an inequality assertion.** The classic
+  equal-objects-have-equal-hashes test is satisfied by `return 0`. Add
+  `assertThat(a.hashCode()).isNotEqualTo(b.hashCode())` for two distinct
+  values to pin the real implementation.
+- **Elvis defaults in `evolve()` accumulators hide real gaps.** A survivor
+  on `state.map[key] ?: zero()` means no test ever exercised the *second*
+  event for the same key. The killing scenario is domain-meaningful: stack
+  the same creature twice and then remove some — accumulation suddenly
+  matters for the army-slot limit.
+
 ## Two flavours of `AxonTestFixture` tests
 
 Every test in this repo uses `AxonTestFixture`, but the construction differs:

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -131,7 +131,7 @@ test run — you do not need to `docker compose up` separately for Pitest.
 
 The workflow at
 [`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml)
-exposes a single `workflow_dispatch` trigger. Open *Actions* → "Mutation
+exposes a single `workflow_dispatch` trigger. Open *Actions* → "🧬 Mutation
 Testing" → "Run workflow", pick the branch, click. The HTML report is
 uploaded as the `pit-report` artifact on the workflow run page.
 

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -1,0 +1,331 @@
+# Mutation Testing with Pitest
+
+This document is the deeper companion to the [README's Mutation Testing
+section](../README.md#-mutation-testing-with-pitest). It covers *why* we run
+Pitest in this project, *how* it's wired, and *how to read the report*.
+
+## What is mutation testing?
+
+Line and branch coverage tell you that a line was executed during a test. They
+do not tell you whether the test would have failed if the line behaved
+differently. Mutation testing closes that gap.
+
+[Pitest](https://pitest.org/) takes the compiled bytecode, makes a small,
+behaviour-changing edit (a *mutant*) — flips a `>` to `>=`, removes a
+conditional, replaces a return value with a default — and re-runs the tests
+that cover the mutated code. If at least one test fails, the mutant is
+*killed*. If every test still passes, the mutant *survives* — meaning the
+production code can be wrong in that exact way and your tests would never
+notice.
+
+### A worked example from this project
+
+Take the cost check inside `RecruitCreature.decide()`:
+
+```kotlin
+if (totalCost > availableResources) {
+    throw NotEnoughResourcesException(...)
+}
+```
+
+Pitest will produce mutants such as:
+
+- replace `>` with `>=` (boundary condition)
+- replace `>` with `<` (negated condition)
+- remove the `if` entirely (conditional removal)
+- replace the throw with a no-op (negate conditional)
+
+A test that recruits with *exactly* the affordable amount kills the `>=`
+mutant. A test that recruits with *more than* affordable resources kills the
+"remove conditional" mutant. If neither test exists, both mutants survive —
+and the survivor list in the report is the actionable feedback: write the
+missing test.
+
+## Why it fits this project
+
+Most legacy advice on mutation testing warns about generated noise, slow
+runs, and equivalent mutants. This project happens to be unusually
+mutation-friendly:
+
+- **`decide()` and `evolve()` are pure functions.** No mocks, no time, no
+  randomness, no I/O. Every mutant is deterministically killed or survives.
+- **Tests assert on observable behaviour** (emitted events, read-model state,
+  dispatched commands) via the `Given/When/Then` DSL. They don't assert on
+  internal method calls, so refactors don't break them and Pitest mutants
+  are measured against the same contract a user cares about.
+- **Vertical slices keep each test focused on one feature**, which means a
+  mutant in `BuildDwelling.Slice.kt` is generally killed by tests in the
+  same slice. Locality keeps the per-mutant cost low.
+
+## How it's wired
+
+The plugin block lives in [`pom.xml`](../pom.xml) under
+`<build><plugins>` after `kotlin-maven-plugin`. Key settings:
+
+- `targetClasses = com.dddheroes.heroesofddd.*` — every class in the
+  production code is a mutation target. No exclusions: application
+  bootstrap, REST controllers, Spring `@Configuration`, DTOs all stay in
+  scope. Pitest only mutates classes that have actual test coverage, so
+  truly unused code shows up as "no coverage" in the report rather than
+  being silently skipped.
+- `targetTests = com.dddheroes.heroesofddd.*` — every test participates.
+  This includes pure `AxonTestFixture` unit tests *and*
+  `@HeroesAxonSpringBootTest` Spring/Testcontainers slice tests.
+- `avoidCallsTo = org.slf4j, java.util.logging` — Pitest never mutates
+  logging calls. These mutants are equivalent by definition.
+- `mutators = DEFAULTS` — Pitest's curated set. Includes the modern
+  return-value mutators (`TRUE_RETURNS`, `FALSE_RETURNS`, `EMPTY_RETURNS`,
+  `NULL_RETURNS`, `PRIMITIVE_RETURNS`) and the conditional / arithmetic
+  mutators. `STRONGER` is a possible follow-up once a baseline is stable.
+- `threads = 2`, `jvmArgs = -Xmx2g` — explicitly bounded parallelism and
+  child-fork heap. Pitest forks one JVM per worker thread to run mutation
+  tests; with Spring/Testcontainers tests in scope each fork may boot its
+  own Spring context, so high thread counts multiply memory usage. The
+  `+auto_threads` feature (one thread per CPU) is *not* used here — on an
+  11-core machine it picks 11 threads, which is enough to OOM-kill the
+  process. See "Limitations and caveats" below for the full story and how
+  to tune for your hardware.
+- `timeoutFactor = 1.5`, `timeoutConstant = 4000` — generous timeouts
+  because some Testcontainers-backed tests take real time.
+
+Incremental analysis (re-mutating only classes that changed since the last
+run) is intentionally **not** wired up. As of Pitest 1.22, the
+`historyInputFile` / `historyOutputFile` settings require the commercial
+[Arcmutate history plugin](https://blog.arcmutate.com/history/). Every
+local or CI run is a full pass.
+
+## Running it locally
+
+Full run:
+
+```bash
+./mvnw test org.pitest:pitest-maven:mutationCoverage
+```
+
+Scoped to a single bounded context — much faster while iterating:
+
+```bash
+./mvnw test org.pitest:pitest-maven:mutationCoverage \
+  -DtargetClasses=com.dddheroes.heroesofddd.creaturerecruitment.* \
+  -DtargetTests=com.dddheroes.heroesofddd.creaturerecruitment.*
+```
+
+Scoped to a single slice:
+
+```bash
+./mvnw test org.pitest:pitest-maven:mutationCoverage \
+  -DtargetClasses=com.dddheroes.heroesofddd.creaturerecruitment.write.recruitcreaturedcb.* \
+  -DtargetTests=com.dddheroes.heroesofddd.creaturerecruitment.write.recruitcreaturedcb.*
+```
+
+Open the report:
+
+```bash
+open target/pit-reports/index.html
+```
+
+The Testcontainers stack starts automatically as part of the underlying
+test run — you do not need to `docker compose up` separately for Pitest.
+
+## Running it on CI
+
+The workflow at
+[`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml)
+exposes a single `workflow_dispatch` trigger. Open *Actions* → "Mutation
+Testing" → "Run workflow", pick the branch, click. The HTML report is
+uploaded as the `pit-report` artifact on the workflow run page.
+
+Why manual only:
+
+- Mutation runs are expensive. The Spring/Testcontainers tests in scope
+  mean a full pass is on the order of minutes — too slow to gate every PR.
+- A scheduled cron would just produce reports nobody reads. Running on
+  demand keeps the signal-to-noise ratio high.
+- Every run is a full pass — incremental analysis would require a paid
+  Arcmutate licence, which is out of scope for this educational repo.
+
+## Reading the report
+
+`target/pit-reports/index.html` is the entry point. Drill down
+to a package, then a class, to see line-by-line mutant detail. Colours:
+
+- **Green** — line is covered *and* every mutant on it was killed.
+- **Yellow** — line is covered, but at least one mutant survived.
+- **Red** — line was not covered by any test.
+- **Grey** — Pitest had no mutator that applied to this line.
+
+For each surviving mutant, the report shows the mutator that produced it
+and the source line. Survivors fall into three buckets:
+
+1. **Real test gap.** The mutant changed observable behaviour and no test
+   detected it. Write the missing assertion.
+2. **Equivalent mutant.** The mutant changed bytecode but not observable
+   behaviour (e.g. swapping `for (i in 0..n)` with `for (i in 0..<n+1)`).
+   No test could reasonably kill it. Move on.
+3. **Generated/synthetic code.** Kotlin generates a lot of bytecode that
+   isn't directly meaningful at the source level — `equals` / `hashCode` /
+   `copy` on `data class`, the synthetic dispatch table for
+   `when (x: SealedType)`, `kotlin.jvm.internal.Intrinsics.checkNotNull*`
+   for null-safety, default-argument bridges (`*$default`). Mutants here
+   are *usually* equivalent and *occasionally* a real signal. Read each
+   one. We deliberately do not exclude these so readers can develop the
+   judgement to recognise them.
+
+A practical workflow: filter the report to surviving mutants in `*.Slice.kt`
+first. That's where killing mutants directly improves your `decide()` /
+`evolve()` confidence.
+
+## Two flavours of `AxonTestFixture` tests
+
+Every test in this repo uses `AxonTestFixture`, but the construction differs:
+
+- **Pure** — e.g.
+  [`RecruitCreatureUnitTest`](../src/test/kotlin/com/dddheroes/heroesofddd/creaturerecruitment/write/recruitcreaturedcb/RecruitCreatureUnitTest.kt).
+  Builds the fixture directly with `axonTestFixture(configSlice { … })`.
+  No Spring context, no Testcontainers. Milliseconds per mutant.
+- **Spring** — e.g. `*SpringSliceTest`, `*RestApiTest`. Autowires the
+  fixture via `@HeroesAxonSpringBootTest`, which boots a Spring context and
+  a Testcontainers Axon Server stack (cached across the suite). Seconds per
+  mutant.
+
+Both styles contribute to mutation coverage and both stay in scope on
+purpose. When you author a *new* slice, prefer the pure pattern — same
+`Given/When/Then` DSL, same assertions, vastly faster mutation feedback.
+
+## Limitations and caveats
+
+- **Kotlin synthetics produce noise.** As described above, expect equivalent
+  mutants on `data class` methods, `when`-over-sealed dispatch tables, null
+  checks, and `*$default` argument bridges. We don't filter them — learning
+  to spot them is part of using Pitest on a Kotlin codebase. The free
+  Pitest Kotlin plugin (`org.pitest:pitest-kotlin-plugin`) was archived in
+  2023 without ever publishing a release to Maven Central; the only
+  Kotlin-specific filtering available today is the commercial Arcmutate
+  Kotlin plugin.
+- **Spring/Testcontainers mutants are slow and memory-hungry.** This
+  warrants a longer explanation because it's the single most common way
+  Pitest runs fail in this project. The pom defaults (`<threads>2</threads>`,
+  `<jvmArgs>-Xmx2g</jvmArgs>`) already lean conservative, but
+  understanding the mechanism helps you tune them.
+
+  **What Pitest does under the hood:** Pitest forks one JVM per worker
+  thread to run mutated tests. Each fork is independent of the Maven
+  parent JVM — `MAVEN_OPTS=-Xmx…` does *not* size the forks. The forks
+  inherit Surefire's `argLine` (modern Pitest auto-inherits this) and the
+  pitest plugin's own `<jvmArgs>`.
+
+  **Why this hurts here:** with `*SpringSliceTest` and `*RestApiTest` in
+  scope, every fork may boot its own Spring `ApplicationContext` and its
+  own Testcontainers stack. The test-context cache keeps that bounded per
+  fork, but doesn't share state across forks. So `threads × per-fork heap`
+  is the real memory cost.
+
+  **Symptoms:** a Maven exit code `137` (process killed), Pitest stopping
+  mid-run with no error in its own log, or `java.lang.OutOfMemoryError`
+  in `target/surefire-reports/`.
+
+  **Three levers to tune, in order of impact:**
+  1. **Scope.** Run Pitest one bounded context at a time
+     (`-DtargetClasses=…creaturerecruitment.*`). Cuts both runtime and
+     peak memory linearly.
+  2. **Thread count.** Lower `<threads>` (or pass `-Dthreads=1` on the
+     command line). One thread = one fork = one Spring context in memory
+     at a time. Slower wall-clock, predictable memory.
+  3. **Per-fork heap.** Raise `<jvmArgs>-Xmx…</jvmArgs>` if individual
+     forks fail with `OutOfMemoryError` rather than the parent being
+     killed. The default `-Xmx2g` is enough for `*UnitTest`-only scopes;
+     for Spring-heavy slices bump to `-Xmx3g` or `-Xmx4g`.
+
+  On CI, GitHub's `ubuntu-latest` runner has roughly 7 GB of usable
+  memory; with the default config (2 threads × 2 GB) you have ~3 GB of
+  headroom for OS + Maven + Docker, which is workable.
+
+### OOM mitigation playbook (try in order)
+
+If the defaults aren't enough on a particular scope, try these in
+ascending order of impact / invasiveness. The earlier options preserve
+report completeness; the later ones trade coverage for survival.
+
+1. **Scope the run.** `-DtargetClasses=…oneContext.*` is by far the
+   biggest lever. Already covered above.
+
+2. **Drop to a single fork.** Pass `-Dthreads=1` (or set
+   `<threads>1</threads>` in the pom). Eliminates concurrent Spring
+   contexts entirely.
+
+3. **Switch the child JVM to G1GC with fixed sizing.** Add to
+   `<jvmArgs>`:
+
+   ```xml
+   <jvmArg>-XX:+UseG1GC</jvmArg>
+   <jvmArg>-Xms2g</jvmArg>
+   <jvmArg>-Xmx2g</jvmArg>
+   ```
+
+   Equal `-Xms`/`-Xmx` prevents heap resize churn during long forks;
+   G1GC handles the Spring-context churn better than the default
+   collector on heaps in the 2-4 GB range.
+
+4. **Enable Testcontainers container reuse.** Pitest re-runs tests once
+   per mutant, so containers boot many times. Setting
+   `TESTCONTAINERS_REUSE_ENABLE=true` in the environment keeps containers
+   alive across runs. ⚠️ This has a known caveat with Pitest: if Spring
+   binds dynamic properties (e.g. container ports) per context, a reused
+   container may have *different* ports than what the first context
+   cached. The project's `@DynamicPropertySource` integration usually
+   handles this correctly, but if you see connection failures rather
+   than OOMs, this is the prime suspect — disable reuse or add
+   `@DirtiesContext` to the affected tests.
+   See [Reusable Containers — Testcontainers for Java](https://java.testcontainers.org/features/reuse/).
+
+5. **Raise per-fork heap, lower thread count proportionally.** On a
+   machine with more RAM, e.g. `<threads>1</threads>` +
+   `<jvmArgs><jvmArg>-Xmx6g</jvmArg></jvmArgs>` lets one well-fed fork
+   crunch through harder slices without OOM.
+
+6. **Limit mutations per class** (last resort — sacrifices coverage).
+   Pitest's `<maxMutationsPerClass>` caps the number of mutants emitted
+   per class. Useful only if a single huge class is producing thousands
+   of mutants and dominating runtime; rarely needed in a vertical-slice
+   codebase.
+
+7. **Out of scope here but worth knowing:** the commercial Arcmutate
+   plugins (`pitest-git-plugin`, Arcmutate Kotlin, Arcmutate Spring) all
+   substantially reduce both runtime and memory by either narrowing the
+   mutation set (`+GIT` diff scoping) or filtering Kotlin/Spring synthetic
+   mutants that consume forks without adding signal.
+
+### Confirmed working configurations on this repo
+
+Measured locally on an 11-core / 32 GB Mac with the pom defaults
+(`<threads>2</threads>`, `<jvmArgs>-Xmx2g</jvmArgs>`):
+
+| Scope | Tests | Mutants | Killed | Wall clock |
+|---|---|---|---|---|
+| Single slice (`*UnitTest` only) | 1 | 38 | 24 (63%) | ~3 s |
+| Single bounded context (`creaturerecruitment.*`, all 65 tests incl. Spring/Testcontainers) | 65 | 123 | 83 (67%) | ~2.5 min |
+| Full project (`com.dddheroes.heroesofddd.*`, all 265 tests) | 265 | 525 | 383 (73%) | ~12 min |
+
+All three runs reported **0 memory errors**. On CI (`ubuntu-latest`, ~7 GB
+usable RAM), expect the full-project run to take longer; if it fails, drop
+`<threads>` to 1 first.
+- **Equivalent mutants are not bugs in Pitest.** Some surviving mutants are
+  genuinely undetectable. The goal is a *trend* in the killed-mutant ratio,
+  not 100%.
+
+## Future tuning
+
+- **Promote to a hard gate.** Once a few runs converge on a baseline,
+  uncomment `<mutationThreshold>` and `<coverageThreshold>` in
+  [`pom.xml`](../pom.xml). Suggested starting values: 60-70 mutation
+  threshold, 80 line coverage. Adjust based on observed survivor patterns.
+- **`STRONGER` mutator group.** Adds `REMOVE_CONDITIONALS_EQUAL_ELSE` and
+  experimental switch mutators. Try once `DEFAULTS` is green.
+- **PR-scoped runs.** The commercial
+  [`com.arcmutate:pitest-git-plugin`](https://docs.arcmutate.com/docs/git-integration)
+  enables `features=+GIT(from[origin/main])` to mutate only classes changed
+  in a PR diff, cutting runtime by 10-50×. Requires an Arcmutate licence;
+  out of scope for this educational repo.
+- **Periodic baseline.** Add a `schedule:` cron to the workflow to publish
+  a fresh report on `main` weekly. Only worth doing once the report is
+  routinely read.

--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,56 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>1.25.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-junit5-plugin</artifactId>
+                        <version>1.2.3</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <targetClasses>
+                        <param>com.dddheroes.heroesofddd.*</param>
+                    </targetClasses>
+                    <targetTests>
+                        <param>com.dddheroes.heroesofddd.*</param>
+                    </targetTests>
+                    <avoidCallsTo>
+                        <param>org.slf4j</param>
+                        <param>java.util.logging</param>
+                    </avoidCallsTo>
+                    <mutators>
+                        <mutator>DEFAULTS</mutator>
+                    </mutators>
+                    <outputFormats>
+                        <param>HTML</param>
+                        <param>XML</param>
+                    </outputFormats>
+                    <timeoutFactor>1.5</timeoutFactor>
+                    <timeoutConstant>4000</timeoutConstant>
+                    <!--
+                        Pitest forks one JVM per worker thread, each with its own heap.
+                        With Spring/Testcontainers tests in scope, every fork may boot
+                        its own Spring context — so high thread counts multiply memory
+                        usage and trigger OOM kills. `+auto_threads` (one thread per CPU)
+                        is too aggressive for this codebase; pin to 2 as a safe default.
+                    -->
+                    <threads>2</threads>
+                    <jvmArgs>
+                        <jvmArg>-Xmx2g</jvmArg>
+                    </jvmArgs>
+                    <!-- historyInputFile / historyOutputFile (incremental analysis) require the
+                         commercial Arcmutate history plugin in Pitest 1.22+. Skipped here. -->
+                    <!-- Enable after a baseline mutation score is established:
+                    <mutationThreshold>70</mutationThreshold>
+                    <coverageThreshold>80</coverageThreshold>
+                    -->
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/test/kotlin/com/dddheroes/heroesofddd/armies/write/addcreaturetoarmy/AddCreatureToArmySpringSliceTest.kt
+++ b/src/test/kotlin/com/dddheroes/heroesofddd/armies/write/addcreaturetoarmy/AddCreatureToArmySpringSliceTest.kt
@@ -136,4 +136,31 @@ internal class AddCreatureToArmySpringSliceTest @Autowired constructor(
             }
         }
     }
+
+    @Test
+    fun `given army with max creature stacks where one stacked twice then partially removed, when add new creature, then failure`() {
+        sliceUnderTest.Scenario {
+            Given {
+                // Behemoth stacked in two batches (11 + 4 = 15)...
+                event(CreatureAddedToArmy(armyId, CreatureId("Centaur"), Quantity(5)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("Angel"), Quantity(1)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("ArchAngel"), Quantity(3)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("BlackDragon"), Quantity(9)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("RedDragon"), Quantity(15)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("Bowman"), Quantity(12)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("Behemoth"), Quantity(11)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("Behemoth"), Quantity(4)), gameMetadata)
+                // ...then partially removed — the stack still occupies an army slot
+                event(CreatureRemovedFromArmy(armyId, CreatureId("Behemoth"), Quantity(12)), gameMetadata)
+            } When {
+                command(
+                    AddCreatureToArmy(armyId, CreatureId("Phoenix"), Quantity(3)),
+                    gameMetadata
+                )
+            } Then {
+                resultMessagePayload(Failure("Can have max 7 different creature stacks in the army"))
+                noEvents()
+            }
+        }
+    }
 }

--- a/src/test/kotlin/com/dddheroes/heroesofddd/armies/write/removecreaturefromarmy/RemoveCreatureFromArmySpringSliceTest.kt
+++ b/src/test/kotlin/com/dddheroes/heroesofddd/armies/write/removecreaturefromarmy/RemoveCreatureFromArmySpringSliceTest.kt
@@ -99,6 +99,25 @@ internal class RemoveCreatureFromArmySpringSliceTest @Autowired constructor(
     }
 
     @Test
+    fun `given creature added twice, when remove partial, then success with accumulated quantity tracked`() {
+        sliceUnderTest.Scenario {
+            Given {
+                event(CreatureAddedToArmy(armyId, CreatureId("Angel"), Quantity(3)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("Angel"), Quantity(2)), gameMetadata)
+            } When {
+                command(
+                    RemoveCreatureFromArmy(armyId, CreatureId("Angel"), Quantity(4)),
+                    gameMetadata
+                )
+            } Then {
+                resultMessagePayload(Success)
+                events(CreatureRemovedFromArmy(armyId, CreatureId("Angel"), Quantity(4)))
+                allEventsHaveMetadata(gameMetadata)
+            }
+        }
+    }
+
+    @Test
     fun `given creature stack removed, when remove same creature again, then failure`() {
         sliceUnderTest.Scenario {
             Given {

--- a/src/test/kotlin/com/dddheroes/heroesofddd/calendar/write/startday/StartDaySpringSliceTest.kt
+++ b/src/test/kotlin/com/dddheroes/heroesofddd/calendar/write/startday/StartDaySpringSliceTest.kt
@@ -72,6 +72,36 @@ internal class StartDaySpringSliceTest @Autowired constructor(
     }
 
     @Test
+    fun `given previous day finished, when start day skipping week, then failure`() {
+        sliceUnderTest.Scenario {
+            Given {
+                event(DayStarted(calendarId, month = Month(1), week = Week(1), day = Day(1)), gameMetadata)
+                event(DayFinished(calendarId, month = Month(1), week = Week(1), day = Day(1)), gameMetadata)
+            } When {
+                command(StartDay(calendarId, month = Month(1), week = Week(2), day = Day(2)), gameMetadata)
+            } Then {
+                resultMessagePayload(CommandHandlerResult.Failure("Cannot skip days"))
+                noEvents()
+            }
+        }
+    }
+
+    @Test
+    fun `given previous day finished, when start day skipping month, then failure`() {
+        sliceUnderTest.Scenario {
+            Given {
+                event(DayStarted(calendarId, month = Month(1), week = Week(1), day = Day(1)), gameMetadata)
+                event(DayFinished(calendarId, month = Month(1), week = Week(1), day = Day(1)), gameMetadata)
+            } When {
+                command(StartDay(calendarId, month = Month(2), week = Week(1), day = Day(2)), gameMetadata)
+            } Then {
+                resultMessagePayload(CommandHandlerResult.Failure("Cannot skip days"))
+                noEvents()
+            }
+        }
+    }
+
+    @Test
     fun `given last day of week finished, when start first day of next week, then DayStarted`() {
         sliceUnderTest.Scenario {
             Given {

--- a/src/test/kotlin/com/dddheroes/heroesofddd/creaturerecruitment/read/getalldwellings/GetAllDwellingsSpringSliceTest.kt
+++ b/src/test/kotlin/com/dddheroes/heroesofddd/creaturerecruitment/read/getalldwellings/GetAllDwellingsSpringSliceTest.kt
@@ -85,6 +85,13 @@ internal class GetAllDwellingsSpringSliceTest @Autowired constructor(
                 assertThat(result.items).containsExactlyInAnyOrder(
                     DwellingReadModel(gameId.raw, dwellingId.raw, creatureId.raw, expectedCost, 5)
                 )
+                // Per-field assertions go through generated getters, killing
+                // EmptyObjectReturnValsMutator / PrimitiveReturnsMutator on the
+                // getters that data-class equals() would otherwise bypass.
+                val item = result.items.single()
+                assertThat(item.creatureId).isEqualTo(creatureId.raw)
+                assertThat(item.costPerTroop).isEqualTo(expectedCost)
+                assertThat(item.availableCreatures).isEqualTo(5)
             }
         }
     }

--- a/src/test/kotlin/com/dddheroes/heroesofddd/creaturerecruitment/write/recruitcreaturedcb/RecruitCreatureUnitTest.kt
+++ b/src/test/kotlin/com/dddheroes/heroesofddd/creaturerecruitment/write/recruitcreaturedcb/RecruitCreatureUnitTest.kt
@@ -1,6 +1,7 @@
 package com.dddheroes.heroesofddd.creaturerecruitment.write.recruitcreaturedcb
 
 import com.dddheroes.heroesofddd.armies.events.CreatureAddedToArmy
+import com.dddheroes.heroesofddd.armies.events.CreatureRemovedFromArmy
 import com.dddheroes.heroesofddd.creaturerecruitment.events.AvailableCreaturesChanged
 import com.dddheroes.heroesofddd.creaturerecruitment.events.CreatureRecruited
 import com.dddheroes.heroesofddd.creaturerecruitment.events.DwellingBuilt
@@ -601,6 +602,64 @@ internal class RecruitCreatureUnitTest {
                             dwellingId = dwellingId,
                             creatureId = existingCreatureId,
                             changedBy = -2,
+                            changedTo = Quantity(0)
+                        )
+                    )
+                }
+            }
+        }
+
+        @Test
+        fun `given army with 7 creature types where one stacked twice then fully removed, when recruit new type, then recruited`() {
+            val dwellingId = DwellingId.random()
+            val armyId = ArmyId.random()
+            val newCreatureId = CreatureId("black-dragon")
+            val costPerTroop = Resources.of(ResourceType.GOLD to 4000, ResourceType.GEMS to 2)
+
+            sliceUnderTest.Scenario {
+                Given {
+                    event(DwellingBuilt(dwellingId, newCreatureId, costPerTroop), gameMetadata)
+                    event(AvailableCreaturesChanged(dwellingId, newCreatureId, changedBy = 1, changedTo = Quantity(1)), gameMetadata)
+                    // Army at the 7-type limit, with angel stacked in two batches (5 + 3 = 8)...
+                    event(CreatureAddedToArmy(armyId, CreatureId("angel"), Quantity(5)), gameMetadata)
+                    event(CreatureAddedToArmy(armyId, CreatureId("griffin"), Quantity(10)), gameMetadata)
+                    event(CreatureAddedToArmy(armyId, CreatureId("swordsman"), Quantity(20)), gameMetadata)
+                    event(CreatureAddedToArmy(armyId, CreatureId("monk"), Quantity(8)), gameMetadata)
+                    event(CreatureAddedToArmy(armyId, CreatureId("cavalier"), Quantity(6)), gameMetadata)
+                    event(CreatureAddedToArmy(armyId, CreatureId("mage"), Quantity(4)), gameMetadata)
+                    event(CreatureAddedToArmy(armyId, CreatureId("titan"), Quantity(2)), gameMetadata)
+                    event(CreatureAddedToArmy(armyId, CreatureId("angel"), Quantity(3)), gameMetadata)
+                    // ...then the whole accumulated angel stack leaves, freeing an army slot
+                    event(CreatureRemovedFromArmy(armyId, CreatureId("angel"), Quantity(8)), gameMetadata)
+                } When {
+                    command(
+                        RecruitCreature(
+                            dwellingId = dwellingId,
+                            creatureId = newCreatureId,
+                            armyId = armyId,
+                            quantity = Quantity(1),
+                            expectedCost = costPerTroop
+                        ), gameMetadata
+                    )
+                } Then {
+                    resultMessagePayload(CommandHandlerResult.Success)
+                    events(
+                        CreatureRecruited(
+                            dwellingId = dwellingId,
+                            creatureId = newCreatureId,
+                            toArmy = armyId,
+                            quantity = Quantity(1),
+                            totalCost = costPerTroop
+                        ),
+                        CreatureAddedToArmy(
+                            armyId = armyId,
+                            creatureId = newCreatureId,
+                            quantity = Quantity(1)
+                        ),
+                        AvailableCreaturesChanged(
+                            dwellingId = dwellingId,
+                            creatureId = newCreatureId,
+                            changedBy = -1,
                             changedTo = Quantity(0)
                         )
                     )

--- a/src/test/kotlin/com/dddheroes/heroesofddd/shared/domain/valueobjects/ResourcesTest.kt
+++ b/src/test/kotlin/com/dddheroes/heroesofddd/shared/domain/valueobjects/ResourcesTest.kt
@@ -312,6 +312,14 @@ internal class ResourcesTest {
         }
 
         @Test
+        fun `should have different hash codes for different resources`() {
+            val resources1 = Resources.of(ResourceType.GOLD to 100)
+            val resources2 = Resources.of(ResourceType.GOLD to 200)
+
+            assertThat(resources1.hashCode()).isNotEqualTo(resources2.hashCode())
+        }
+
+        @Test
         fun `should not be equal when different types`() {
             val resources1 = Resources.of(ResourceType.GOLD to 100)
             val resources2 = Resources.of(ResourceType.WOOD to 100)


### PR DESCRIPTION
## What

Integrates [Pitest](https://pitest.org/) mutation testing into the project, runs it against the full test suite, and kills the actionable surviving mutants it found.

- **`pom.xml`** — `pitest-maven 1.25.1` + `pitest-junit5-plugin 1.2.3`, scoped to all classes and all tests under `com.dddheroes.heroesofddd.*` (no exclusions). Conservative defaults (`threads=2`, `-Xmx2g`) because Spring/Testcontainers tests are in scope — Pitest forks one JVM per thread and each fork may boot its own Spring context.
- **`.github/workflows/mutation-testing.yml`** — one-click `workflow_dispatch`-only workflow; the HTML report is uploaded as the `pit-report` artifact. Manual only, since mutation runs are too expensive to gate every push/PR.
- **`README.md`** — "🧬 Mutation Testing with Pitest" section under Testing: what it is, why it fits `decide()`/`evolve()` slices, how to run locally (full / bounded-context / single-slice scope) and on CI.
- **`docs/MUTATION_TESTING.md`** — deeper guide: how it's wired, reading the report, survivor triage heuristics learned from this codebase (inlined `resultOf { }` line-number artifacts, the `?.let ?: ` equivalent mutant, data-class `equals()` bypassing getters, elvis accumulator gaps in `evolve()`), OOM mitigation playbook, measured baselines.

## Mutants killed

Survivor triage on the full-project baseline (525 mutants, 383 killed, 73%) surfaced real test gaps, fixed here — by adding tests only, production code stays idiomatic:

- `GetAllDwellings` — per-field assertions on the read model (data-class `equals()` reads fields directly, bypassing the generated getters Pitest mutates)
- `RemoveCreatureFromArmy` / `RecruitCreature` (DCB) / `AddCreatureToArmy` — the `?: Quantity.zero()` accumulator in `evolve()` was never exercised with a second add of the same creature; new stack-twice-then-remove scenarios make accumulation observable via the 7-creature-type army limit
- `StartDay` — "Cannot skip days" guard checks day, week AND month, but only day-skipping was tested
- `Resources.hashCode` — equal-objects test is satisfied by a `return 0` mutant; added inequality assertion

Survivors that are equivalent mutants from Kotlin's compilation strategy (null-safety `Intrinsics`, the `?.let ?: ` double null-check, inlined `resultOf { }` helpers) are deliberately **not** "fixed" by bending the code — they're documented as the known noise floor in `docs/MUTATION_TESTING.md`.

## How to verify

```bash
# fast: one slice
./mvnw test org.pitest:pitest-maven:mutationCoverage \
  -DtargetClasses=com.dddheroes.heroesofddd.creaturerecruitment.write.recruitcreaturedcb.* \
  -DtargetTests=com.dddheroes.heroesofddd.creaturerecruitment.write.recruitcreaturedcb.*

# full project (~12 min locally)
./mvnw test org.pitest:pitest-maven:mutationCoverage
open target/pit-reports/index.html
```

Or trigger the "🧬 Mutation Testing" workflow from the Actions tab and download the `pit-report` artifact.