### PR TITLE
🧑‍💻 chore(dx): Conductor setup — scripts as files, action prompts, git hygiene, code-review skill

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: code-review
+description: "Project-specific review checklist for this repository (DDD + Event Sourcing + Axon Framework 5 invariants). Use when: (1) reviewing code changes, a diff, or a pull request in this repository, (2) user says 'review', 'code review', 'check this change', (3) any automated review action runs for this repo."
+---
+
+# Code Review Checklist
+
+Project-specific invariants to verify when reviewing changes in this repository.
+These complement (not replace) general review practice: correctness, security,
+performance, and missing tests.
+
+## Event Sourcing invariants
+
+- **Exhaustive `when (event)` in `evolve()`** — must switch over the sealed
+  interface with an explicit branch per subtype. No `else ->` branch, ever.
+  No-op branches (`is SomeEvent -> state`) are required and intentional —
+  they document a conscious "this event doesn't affect my state here" decision.
+- **`@EventSourcingHandler` only on state-mutating events** — branches that
+  return `state` unchanged must NOT have a corresponding handler.
+- **Every state-mutating branch has a test** for that state transition.
+- **`decide()` and `evolve()` stay pure** — no side effects, no infrastructure
+  dependencies in the Domain section.
+
+## Testing invariants
+
+- **`gameMetadata` passed to every `event()` and `command()` call in tests** —
+  events without metadata break `MetadataSequencingPolicy` and cause processor
+  failures with shared Testcontainers.
+- Integration tests use `@HeroesAxonSpringBootTest`, never bare
+  `@AxonSpringBootTest`.
+- Prefer constructor injection over field injection, also in tests.
+
+## Domain modeling invariants
+
+- **Value classes validate invariants in `init` blocks** — domain concepts
+  (`Day`, `Gold`, `Quantity`, …) must reject invalid values at construction.
+- All domain events implement `HeroesEvent`; module events extend their own
+  sealed interface (e.g. `DwellingEvent`).
+- State classes are `internal`; commands are `public`.
+
+## Slice structure invariants
+
+- One slice per file (`FeatureName.Slice.kt`) with Domain / Application /
+  Presentation sections.
+- **Feature flags** — every new slice needs `@ConditionalOnProperty` plus
+  entries in `application.yaml` and Spring configuration metadata.
+- REST endpoints follow `games/{gameId}/...`; player ID via `X-Player-ID`
+  header; game-scoped singletons use a fixed path segment, not a path variable.
+
+## Verification
+
+Prefer the narrowest check: run the affected slice's test class
+(`./mvnw test -Dtest=FeatureNameTest`), not the whole suite.

--- a/.conductor/archive.sh
+++ b/.conductor/archive.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Conductor archive script — runs before the workspace is archived.
+# Tears down this workspace's docker compose stack (compose project name is
+# derived from the workspace directory) including volumes. Skips gracefully
+# when the Docker daemon is not running so archiving never fails on it.
+# Docs: https://conductor.build/docs/reference/scripts
+set -euo pipefail
+
+if docker info >/dev/null 2>&1; then
+  docker compose down -v --remove-orphans
+else
+  echo "Docker daemon not running — skipping compose teardown."
+fi

--- a/.conductor/run.sh
+++ b/.conductor/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Conductor run script — started by the Run button (and after setup via
+# auto_run_after_setup). Runs the test suite; Testcontainers gives each
+# workspace isolated containers, so concurrent runs are safe.
+# Docs: https://conductor.build/docs/reference/scripts/run
+set -euo pipefail
+
+./mvnw -B test

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,7 +1,71 @@
 "$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+# Repo-shared Conductor settings. Personal overrides: .conductor/settings.local.toml (gitignored).
+# Docs: https://conductor.build/docs/configure-your-project
 
 [scripts]
-archive = "docker compose down -v --remove-orphans"
-run = "./mvnw -B test"
+# All scripts live as committed files in .conductor/ — see each file for details.
+# Scripts run from the workspace directory, so relative paths work.
+setup = "./.conductor/setup.sh"
+run = "./.conductor/run.sh"
 run_mode = "concurrent"
-setup = "./mvnw -B -q -DskipTests dependency:go-offline test-compile"
+# New in Conductor 0.63: kick off the run script (unit tests) as soon as a new
+# workspace finishes setup, so every workspace starts with a green baseline.
+auto_run_after_setup = true
+archive = "./.conductor/archive.sh"
+
+[git]
+# Tidy up automatically: archive the workspace when its PR merges and drop the branch.
+archive_on_merge = true
+delete_branch_on_archive = true
+worktree_push_auto_setup_remote = true
+# Branch naming for new workspaces:
+#branch_prefix_type = "custom"   # how prefixes are generated
+#branch_prefix = "feature/"      # custom prefix
+
+# Repo-scoped action prompts (Conductor 0.62+). These apply to ALL agents
+# (Claude Code, Codex, Cursor Composer), not just ones that read CLAUDE.md.
+# They are layered ON TOP of Conductor's built-in action prompts, with priority.
+[prompts]
+# Prompts are inline strings only (no native file reference), so this points at the
+# project skill that holds the actual checklist: .claude/skills/code-review/SKILL.md
+code_review = "Use the code-review skill (.claude/skills/code-review/SKILL.md) and verify the project invariants it lists. If neither the skill nor the file is available, review against the conventions in CLAUDE.md instead."
+create_pr = "Create commits using the commit skill (.claude/skills/commit/SKILL.md): Conventional Commits + Gitmoji. Never include AI/Claude attribution in commits or PR descriptions."
+# Appended to every agent session in this repo (all agent types: Claude Code, Codex, Cursor).
+#general = "<project-wide rules: e.g. Vertical Slice Architecture, one slice per file; run the narrowest relevant tests with ./mvnw test -Dtest=...>"
+# Used by the Fix Errors action (when checks/tests fail).
+#fix_errors = "<how to diagnose: e.g. run the failing test class first; check Axon Server/Testcontainers logs; never weaken assertions to make tests pass>"
+# Used by the Resolve Merge Conflicts action.
+#resolve_merge_conflicts = "<conflict policy: e.g. preserve both slices when conflicts touch application.yaml feature flags; rerun affected slice tests after resolving>"
+# Used by the Rename Branch action.
+#rename_branch = "<branch naming scheme: e.g. feature/<context>-<slice-name>, kebab-case, no ticket numbers>"
+
+# --- Other available repo settings (uncomment when needed) ---
+
+# Environment variables passed to agents in this repo (top-level = local + cloud).
+#[environment_variables]
+#MY_VAR = "value"
+#[environment_variables.local]
+#LOCAL_ONLY_VAR = "value"
+#[environment_variables.cloud]
+#CLOUD_ONLY_VAR = "value"
+
+# Or load them from committed env files:
+#environment_variable_files = [".env.conductor"]
+
+# Files copied into each new workspace — NOT used here: .worktreeinclude at the
+# repo root takes precedence and already covers this.
+#file_include_globs = ".env*\n"
+
+# Run this repo from the repository root instead of worktrees (per-repo Spotlight,
+# Conductor 0.55+). Not needed: tests run fine from worktrees via Testcontainers.
+#spotlight_testing = true
+
+# Provider / enterprise options:
+#enterprise_data_privacy = true
+#claude_provider = "anthropic"        # or "bedrock", "vertex"
+#bedrock_region = "us-east-1"
+#vertex_project_id = "my-gcp-project"
+#claude_code_executable_path = "/path/to/claude"
+#codex_executable_path = "/path/to/codex"
+#codex_provider = "openai"
+#ssh_key_path = "~/.ssh/id_ed25519"   # SSH key for cloud workspaces

--- a/.conductor/setup.sh
+++ b/.conductor/setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Conductor setup script — runs once when a workspace is created (from the workspace dir).
+# Docs: https://conductor.build/docs/reference/scripts/setup
+set -euo pipefail
+
+# Keep the root checkout current (documented Conductor pattern); local-only and
+# never fails setup when the root branch can't fast-forward.
+if [ "${CONDUCTOR_IS_LOCAL:-1}" = "1" ] && [ -n "${CONDUCTOR_ROOT_PATH:-}" ]; then
+  git -C "$CONDUCTOR_ROOT_PATH" fetch --prune origin && git -C "$CONDUCTOR_ROOT_PATH" pull --ff-only || true
+fi
+
+# Warm the Maven repo and compile sources + tests so the first agent run is fast.
+./mvnw -B -q -DskipTests dependency:go-offline test-compile

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ build/
 CLAUDE.local.md
 .ai/temp/
 .claude/worktrees/
+# Conductor: personal per-machine overrides (see https://conductor.build/docs/configure-your-project)
+.conductor/settings.local.toml


### PR DESCRIPTION
Improves the Conductor repository setup using features from recent releases (0.55–0.63).

## Changes

### `.conductor/settings.toml`
- **Scripts extracted to committed files** (`.conductor/{setup,run,archive}.sh`) referenced by relative path — reviewable, shellcheck-able, no TOML escaping.
- **`auto_run_after_setup = true`** (Conductor 0.63) — every new workspace runs the test suite right after setup for a green baseline.
- **`[git]` hygiene** — `archive_on_merge`, `delete_branch_on_archive`, `worktree_push_auto_setup_remote`.
- **`[prompts]` action prompts** (repo-scoped since 0.62, apply to all agent types):
  - `code_review` → points at the `code-review` project skill
  - `create_pr` → commit via the `commit` skill, Conventional Commits + Gitmoji, no AI attribution
  - remaining slots (`general`, `fix_errors`, `resolve_merge_conflicts`, `rename_branch`) documented as commented placeholders
- All other available repo settings documented as commented placeholders (env vars, spotlight, providers, …).

### Scripts
- `setup.sh` — fast-forwards the root checkout (local only), warms Maven repo, compiles sources + tests.
- `run.sh` — runs the test suite; concurrent-safe via Testcontainers.
- `archive.sh` — tears down the workspace compose stack; skips gracefully when the Docker daemon isn't running.

### `.claude/skills/code-review/SKILL.md`
New project skill with the repo's review invariants (exhaustive `when(event)` in `evolve()`, `@EventSourcingHandler` only for state-mutating events, `gameMetadata` in all test messages, value-class invariants, feature flags, slice structure). Referenced by the Conductor Review action, auto-triggers in regular sessions, and readable as plain Markdown by non-Claude agents.

### `.gitignore`
- `.conductor/settings.local.toml` (personal per-machine overrides).

## Notes
- Custom action prompts extend Conductor's built-in defaults (layered on top with priority), they don't replace them.
- Settings take effect for workspaces created after this merges.