### PR TITLE
✅ test: cover untested behaviours in calendar, armies and shared value objects

### DIFF
--- a/src/test/kotlin/com/dddheroes/heroesofddd/armies/write/addcreaturetoarmy/AddCreatureToArmySpringSliceTest.kt
+++ b/src/test/kotlin/com/dddheroes/heroesofddd/armies/write/addcreaturetoarmy/AddCreatureToArmySpringSliceTest.kt
@@ -136,4 +136,31 @@ internal class AddCreatureToArmySpringSliceTest @Autowired constructor(
             }
         }
     }
+
+    @Test
+    fun `given army with max creature stacks where one stacked twice then partially removed, when add new creature, then failure`() {
+        sliceUnderTest.Scenario {
+            Given {
+                // Behemoth stacked in two batches (11 + 4 = 15)...
+                event(CreatureAddedToArmy(armyId, CreatureId("Centaur"), Quantity(5)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("Angel"), Quantity(1)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("ArchAngel"), Quantity(3)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("BlackDragon"), Quantity(9)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("RedDragon"), Quantity(15)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("Bowman"), Quantity(12)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("Behemoth"), Quantity(11)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("Behemoth"), Quantity(4)), gameMetadata)
+                // ...then partially removed — the stack still occupies an army slot
+                event(CreatureRemovedFromArmy(armyId, CreatureId("Behemoth"), Quantity(12)), gameMetadata)
+            } When {
+                command(
+                    AddCreatureToArmy(armyId, CreatureId("Phoenix"), Quantity(3)),
+                    gameMetadata
+                )
+            } Then {
+                resultMessagePayload(Failure("Can have max 7 different creature stacks in the army"))
+                noEvents()
+            }
+        }
+    }
 }

--- a/src/test/kotlin/com/dddheroes/heroesofddd/armies/write/removecreaturefromarmy/RemoveCreatureFromArmySpringSliceTest.kt
+++ b/src/test/kotlin/com/dddheroes/heroesofddd/armies/write/removecreaturefromarmy/RemoveCreatureFromArmySpringSliceTest.kt
@@ -99,6 +99,25 @@ internal class RemoveCreatureFromArmySpringSliceTest @Autowired constructor(
     }
 
     @Test
+    fun `given creature added twice, when remove partial, then success with accumulated quantity tracked`() {
+        sliceUnderTest.Scenario {
+            Given {
+                event(CreatureAddedToArmy(armyId, CreatureId("Angel"), Quantity(3)), gameMetadata)
+                event(CreatureAddedToArmy(armyId, CreatureId("Angel"), Quantity(2)), gameMetadata)
+            } When {
+                command(
+                    RemoveCreatureFromArmy(armyId, CreatureId("Angel"), Quantity(4)),
+                    gameMetadata
+                )
+            } Then {
+                resultMessagePayload(Success)
+                events(CreatureRemovedFromArmy(armyId, CreatureId("Angel"), Quantity(4)))
+                allEventsHaveMetadata(gameMetadata)
+            }
+        }
+    }
+
+    @Test
     fun `given creature stack removed, when remove same creature again, then failure`() {
         sliceUnderTest.Scenario {
             Given {

--- a/src/test/kotlin/com/dddheroes/heroesofddd/calendar/write/startday/StartDaySpringSliceTest.kt
+++ b/src/test/kotlin/com/dddheroes/heroesofddd/calendar/write/startday/StartDaySpringSliceTest.kt
@@ -72,6 +72,36 @@ internal class StartDaySpringSliceTest @Autowired constructor(
     }
 
     @Test
+    fun `given previous day finished, when start day skipping week, then failure`() {
+        sliceUnderTest.Scenario {
+            Given {
+                event(DayStarted(calendarId, month = Month(1), week = Week(1), day = Day(1)), gameMetadata)
+                event(DayFinished(calendarId, month = Month(1), week = Week(1), day = Day(1)), gameMetadata)
+            } When {
+                command(StartDay(calendarId, month = Month(1), week = Week(2), day = Day(2)), gameMetadata)
+            } Then {
+                resultMessagePayload(CommandHandlerResult.Failure("Cannot skip days"))
+                noEvents()
+            }
+        }
+    }
+
+    @Test
+    fun `given previous day finished, when start day skipping month, then failure`() {
+        sliceUnderTest.Scenario {
+            Given {
+                event(DayStarted(calendarId, month = Month(1), week = Week(1), day = Day(1)), gameMetadata)
+                event(DayFinished(calendarId, month = Month(1), week = Week(1), day = Day(1)), gameMetadata)
+            } When {
+                command(StartDay(calendarId, month = Month(2), week = Week(1), day = Day(2)), gameMetadata)
+            } Then {
+                resultMessagePayload(CommandHandlerResult.Failure("Cannot skip days"))
+                noEvents()
+            }
+        }
+    }
+
+    @Test
     fun `given last day of week finished, when start first day of next week, then DayStarted`() {
         sliceUnderTest.Scenario {
             Given {

--- a/src/test/kotlin/com/dddheroes/heroesofddd/creaturerecruitment/read/getalldwellings/GetAllDwellingsSpringSliceTest.kt
+++ b/src/test/kotlin/com/dddheroes/heroesofddd/creaturerecruitment/read/getalldwellings/GetAllDwellingsSpringSliceTest.kt
@@ -85,6 +85,12 @@ internal class GetAllDwellingsSpringSliceTest @Autowired constructor(
                 assertThat(result.items).containsExactlyInAnyOrder(
                     DwellingReadModel(gameId.raw, dwellingId.raw, creatureId.raw, expectedCost, 5)
                 )
+                // Not redundant with the equality above: data-class equals() reads
+                // fields directly, so only per-field assertions exercise the getters.
+                val item = result.items.single()
+                assertThat(item.creatureId).isEqualTo(creatureId.raw)
+                assertThat(item.costPerTroop).isEqualTo(expectedCost)
+                assertThat(item.availableCreatures).isEqualTo(5)
             }
         }
     }

--- a/src/test/kotlin/com/dddheroes/heroesofddd/creaturerecruitment/write/recruitcreaturedcb/RecruitCreatureUnitTest.kt
+++ b/src/test/kotlin/com/dddheroes/heroesofddd/creaturerecruitment/write/recruitcreaturedcb/RecruitCreatureUnitTest.kt
@@ -1,6 +1,7 @@
 package com.dddheroes.heroesofddd.creaturerecruitment.write.recruitcreaturedcb
 
 import com.dddheroes.heroesofddd.armies.events.CreatureAddedToArmy
+import com.dddheroes.heroesofddd.armies.events.CreatureRemovedFromArmy
 import com.dddheroes.heroesofddd.creaturerecruitment.events.AvailableCreaturesChanged
 import com.dddheroes.heroesofddd.creaturerecruitment.events.CreatureRecruited
 import com.dddheroes.heroesofddd.creaturerecruitment.events.DwellingBuilt
@@ -601,6 +602,64 @@ internal class RecruitCreatureUnitTest {
                             dwellingId = dwellingId,
                             creatureId = existingCreatureId,
                             changedBy = -2,
+                            changedTo = Quantity(0)
+                        )
+                    )
+                }
+            }
+        }
+
+        @Test
+        fun `given army with 7 creature types where one stacked twice then fully removed, when recruit new type, then recruited`() {
+            val dwellingId = DwellingId.random()
+            val armyId = ArmyId.random()
+            val newCreatureId = CreatureId("black-dragon")
+            val costPerTroop = Resources.of(ResourceType.GOLD to 4000, ResourceType.GEMS to 2)
+
+            sliceUnderTest.Scenario {
+                Given {
+                    event(DwellingBuilt(dwellingId, newCreatureId, costPerTroop), gameMetadata)
+                    event(AvailableCreaturesChanged(dwellingId, newCreatureId, changedBy = 1, changedTo = Quantity(1)), gameMetadata)
+                    // Army at the 7-type limit, with angel stacked in two batches (5 + 3 = 8)...
+                    event(CreatureAddedToArmy(armyId, CreatureId("angel"), Quantity(5)), gameMetadata)
+                    event(CreatureAddedToArmy(armyId, CreatureId("griffin"), Quantity(10)), gameMetadata)
+                    event(CreatureAddedToArmy(armyId, CreatureId("swordsman"), Quantity(20)), gameMetadata)
+                    event(CreatureAddedToArmy(armyId, CreatureId("monk"), Quantity(8)), gameMetadata)
+                    event(CreatureAddedToArmy(armyId, CreatureId("cavalier"), Quantity(6)), gameMetadata)
+                    event(CreatureAddedToArmy(armyId, CreatureId("mage"), Quantity(4)), gameMetadata)
+                    event(CreatureAddedToArmy(armyId, CreatureId("titan"), Quantity(2)), gameMetadata)
+                    event(CreatureAddedToArmy(armyId, CreatureId("angel"), Quantity(3)), gameMetadata)
+                    // ...then the whole accumulated angel stack leaves, freeing an army slot
+                    event(CreatureRemovedFromArmy(armyId, CreatureId("angel"), Quantity(8)), gameMetadata)
+                } When {
+                    command(
+                        RecruitCreature(
+                            dwellingId = dwellingId,
+                            creatureId = newCreatureId,
+                            armyId = armyId,
+                            quantity = Quantity(1),
+                            expectedCost = costPerTroop
+                        ), gameMetadata
+                    )
+                } Then {
+                    resultMessagePayload(CommandHandlerResult.Success)
+                    events(
+                        CreatureRecruited(
+                            dwellingId = dwellingId,
+                            creatureId = newCreatureId,
+                            toArmy = armyId,
+                            quantity = Quantity(1),
+                            totalCost = costPerTroop
+                        ),
+                        CreatureAddedToArmy(
+                            armyId = armyId,
+                            creatureId = newCreatureId,
+                            quantity = Quantity(1)
+                        ),
+                        AvailableCreaturesChanged(
+                            dwellingId = dwellingId,
+                            creatureId = newCreatureId,
+                            changedBy = -1,
                             changedTo = Quantity(0)
                         )
                     )

--- a/src/test/kotlin/com/dddheroes/heroesofddd/shared/domain/valueobjects/ResourcesTest.kt
+++ b/src/test/kotlin/com/dddheroes/heroesofddd/shared/domain/valueobjects/ResourcesTest.kt
@@ -312,6 +312,14 @@ internal class ResourcesTest {
         }
 
         @Test
+        fun `should have different hash codes for different resources`() {
+            val resources1 = Resources.of(ResourceType.GOLD to 100)
+            val resources2 = Resources.of(ResourceType.GOLD to 200)
+
+            assertThat(resources1.hashCode()).isNotEqualTo(resources2.hashCode())
+        }
+
+        @Test
         fun `should not be equal when different types`() {
             val resources1 = Resources.of(ResourceType.GOLD to 100)
             val resources2 = Resources.of(ResourceType.WOOD to 100)


### PR DESCRIPTION
## What

Test-only PR — adds missing scenarios uncovered during a test-quality analysis of the slices. No production code changes.

## Gaps covered

- **`StartDay`** — the "Cannot skip days" rule guards day, week **and** month, but only day-skipping had a test. Added skipped-week and skipped-month failure scenarios.
- **`RecruitCreature` (DCB) / `AddCreatureToArmy`** — creature-stack accumulation across multiple `CreatureAddedToArmy` events for the same creature was never exercised. Combined with partial/full removals, accumulation determines whether a stack keeps occupying one of the 7 army slots:
  - DCB slice: a creature stacked in two batches and then fully removed frees a slot → recruiting a 7th type succeeds
  - `AddCreatureToArmy`: a twice-stacked creature partially removed still occupies its slot → adding an 8th type fails
- **`RemoveCreatureFromArmy`** — removing from an accumulated (twice-added) stack was untested.
- **`GetAllDwellings`** — read-model fields asserted individually; data-class equality reads fields directly, so whole-object assertions never exercise the getters.
- **`Resources`** — `hashCode` was pinned only by the equal-objects-equal-hashes test, which a constant `hashCode` would satisfy. Added an inequality assertion for distinct values.

## Verification

```bash
./mvnw test -Dtest='GetAllDwellingsSpringSliceTest,RemoveCreatureFromArmySpringSliceTest,ResourcesTest,StartDaySpringSliceTest,RecruitCreatureUnitTest,AddCreatureToArmySpringSliceTest'
```

All 79 tests green locally.